### PR TITLE
Client: Alter Offer Requests API

### DIFF
--- a/src/Duffel/Client.php
+++ b/src/Duffel/Client.php
@@ -56,7 +56,7 @@ class Client {
     return new Airports($this);
   }
 
-  public function offer_requests(): OfferRequests {
+  public function offerRequests(): OfferRequests {
     return new OfferRequests($this);
   }
 

--- a/tests/Duffel/ClientTest.php
+++ b/tests/Duffel/ClientTest.php
@@ -51,7 +51,7 @@ class ClientTest extends TestCase {
   }
 
   public function testOfferRequestsUsesApiClass(): void {
-    $this->assertInstanceOf(OfferRequests::class, $this->subject->offer_requests());
+    $this->assertInstanceOf(OfferRequests::class, $this->subject->offerRequests());
   }
 
   public function testOffersUsesApiClass(): void {


### PR DESCRIPTION
💁 The original method/property `offer_requests` on `Duffel\Client` didn't fit the common PHP method naming patterns. These changes rename it to `offerRequests`.

I'll follow that naming convention for future methods which will be added to `Duffel\Client`.