### PR TITLE
API: Order Change Requests

### DIFF
--- a/src/Duffel/Api/OrderChangeRequests.php
+++ b/src/Duffel/Api/OrderChangeRequests.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duffel\Api;
+
+class OrderChangeRequests extends AbstractApi {
+  public function create(string $orderId, array $slices) {
+    $params = array(
+      "slices" => $slices,
+      "order_id" => $orderId,
+    );
+
+    return $this->post('/air/order_change_requests', \array_filter($params, function ($value) {
+      return null !== $value && (!\is_string($value) || '' !== $value);
+    }));
+  }
+
+  public function show(string $id) {
+    return $this->get('/air/order_change_requests/'.self::encodePath($id));
+  }
+}

--- a/src/Duffel/Client.php
+++ b/src/Duffel/Client.php
@@ -10,6 +10,7 @@ use Duffel\Api\Airports;
 use Duffel\Api\OfferRequests;
 use Duffel\Api\Offers;
 use Duffel\Api\OrderCancellations;
+use Duffel\Api\OrderChangeRequests;
 use Duffel\Api\Orders;
 use Duffel\Api\SeatMaps;
 use Duffel\Exception\InvalidAccessTokenException;
@@ -68,6 +69,10 @@ class Client {
 
   public function orderCancellations(): OrderCancellations {
     return new OrderCancellations($this);
+  }
+
+  public function orderChangeRequests(): OrderChangeRequests {
+    return new OrderChangeRequests($this);
   }
 
   public function orders(): Orders {

--- a/tests/Duffel/Api/OrderChangeRequestsTest.php
+++ b/tests/Duffel/Api/OrderChangeRequestsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duffel\Tests\Api;
+
+use Duffel\Api\OrderChangeRequests;
+use Duffel\Client;
+use Http\Client\Common\HttpMethodsClientInterface;
+use PHPUnit\Framework\TestCase;
+
+class OrderChangeRequestsTest extends TestCase {
+  private $mock;
+  private $stub;
+
+  public function setUp(): void {
+    $this->mock = $this->createMock(HttpMethodsClientInterface::class);
+    $this->stub = $this->createStub(Client::class);
+    $this->stub->method('getHttpClient')
+               ->willReturn($this->mock);
+  }
+
+  public function testCreateWithOfferAndPassengersAndPaymentsCallsGetWithExpectedUri(): void {
+    $this->mock->expects($this->once())
+               ->method('post')
+               ->with(
+                 $this->equalTo('/air/order_change_requests'),
+                 $this->equalTo(['Content-Type' => 'application/json']),
+                 $this->equalTo('{"data":{"slices":{"slices":{"remove":[{"slice_id":"sli_00009htYpSCXrwaB9Dn123"}],"add":[{"origin":"LHR","destination":"JFK","departure_date":"2022-05-20","cabin_class":"economy"}]}},"order_id":"ord_0000A3bQ8FJIQoEfuC07n6"}}')
+               );
+
+    $actual = new OrderChangeRequests($this->stub);
+    $actual->create('ord_0000A3bQ8FJIQoEfuC07n6', [
+      'slices' => [
+        'remove' => [
+          [
+            'slice_id' => 'sli_00009htYpSCXrwaB9Dn123',
+          ],
+        ],
+        'add' => [
+          [
+            'origin' => 'LHR',
+            'destination' => 'JFK',
+            'departure_date' => '2022-05-20',
+            'cabin_class' => 'economy',
+          ],
+        ],
+      ],
+    ]);
+  }
+
+  public function testShowWithIdCallsGetWithExpectedUri(): void {
+    $this->mock->expects($this->once())
+               ->method('get')
+               ->with($this->equalTo('/air/order_change_requests/some-id'));
+
+    $actual = new OrderChangeRequests($this->stub);
+    $actual->show('some-id');
+  }
+}

--- a/tests/Duffel/ClientTest.php
+++ b/tests/Duffel/ClientTest.php
@@ -10,6 +10,7 @@ use Duffel\Api\Airports;
 use Duffel\Api\OfferRequests;
 use Duffel\Api\Offers;
 use Duffel\Api\OrderCancellations;
+use Duffel\Api\OrderChangeRequests;
 use Duffel\Api\Orders;
 use Duffel\Api\SeatMaps;
 use Duffel\Client;
@@ -62,6 +63,10 @@ class ClientTest extends TestCase {
 
   public function testOrderCancellationsUsesApiClass(): void {
     $this->assertInstanceOf(OrderCancellations::class, $this->subject->orderCancellations());
+  }
+
+  public function testOrderChangeRequestsUsesApiClass(): void {
+    $this->assertInstanceOf(OrderChangeRequests::class, $this->subject->orderChangeRequests());
   }
 
   public function testOrdersUsesApiClass(): void {


### PR DESCRIPTION
💁 These changes add functionality for querying Duffel's [Order Change Requests API](http://duffel.com/docs/api/order-change-requests).