### PR TITLE
Rename test classes to match filenames

### DIFF
--- a/tests/Duffel/Api/AbstractApiTest.php
+++ b/tests/Duffel/Api/AbstractApiTest.php
@@ -10,7 +10,7 @@ use Duffel\HttpClient\Builder;
 use Http\Mock\Client as MockClient;
 use PHPUnit\Framework\TestCase;
 
-class TestAbstractApi extends TestCase {
+class AbstractApiTest extends TestCase {
   private $builder;
   private $client;
   private $mock;

--- a/tests/Duffel/Api/AircraftTest.php
+++ b/tests/Duffel/Api/AircraftTest.php
@@ -9,7 +9,7 @@ use Duffel\Client;
 use Http\Client\Common\HttpMethodsClientInterface;
 use PHPUnit\Framework\TestCase;
 
-class TestAircraft extends TestCase {
+class AircraftTest extends TestCase {
   private $mock;
   private $stub;
 

--- a/tests/Duffel/Api/AirlinesTest.php
+++ b/tests/Duffel/Api/AirlinesTest.php
@@ -9,7 +9,7 @@ use Duffel\Client;
 use Http\Client\Common\HttpMethodsClientInterface;
 use PHPUnit\Framework\TestCase;
 
-class TestAirlines extends TestCase {
+class AirlinesTest extends TestCase {
   private $mock;
   private $stub;
 

--- a/tests/Duffel/Api/AirportsTest.php
+++ b/tests/Duffel/Api/AirportsTest.php
@@ -9,7 +9,7 @@ use Duffel\Client;
 use Http\Client\Common\HttpMethodsClientInterface;
 use PHPUnit\Framework\TestCase;
 
-class TestAirports extends TestCase {
+class AirportsTest extends TestCase {
   private $mock;
   private $stub;
 

--- a/tests/Duffel/Api/OfferRequestsTest.php
+++ b/tests/Duffel/Api/OfferRequestsTest.php
@@ -9,7 +9,7 @@ use Duffel\Client;
 use Http\Client\Common\HttpMethodsClientInterface;
 use PHPUnit\Framework\TestCase;
 
-class TestOfferRequests extends TestCase {
+class OfferRequestsTest extends TestCase {
   private $mock;
   private $stub;
 

--- a/tests/Duffel/Api/OffersTest.php
+++ b/tests/Duffel/Api/OffersTest.php
@@ -9,7 +9,7 @@ use Duffel\Client;
 use Http\Client\Common\HttpMethodsClientInterface;
 use PHPUnit\Framework\TestCase;
 
-class TestOffers extends TestCase {
+class OffersTest extends TestCase {
   private $mock;
   private $stub;
 

--- a/tests/Duffel/Api/OrderCancellationsTest.php
+++ b/tests/Duffel/Api/OrderCancellationsTest.php
@@ -9,7 +9,7 @@ use Duffel\Client;
 use Http\Client\Common\HttpMethodsClientInterface;
 use PHPUnit\Framework\TestCase;
 
-class TestOrderCancellations extends TestCase {
+class OrderCancellationsTest extends TestCase {
   private $mock;
   private $stub;
 

--- a/tests/Duffel/Api/OrdersTest.php
+++ b/tests/Duffel/Api/OrdersTest.php
@@ -9,7 +9,7 @@ use Duffel\Client;
 use Http\Client\Common\HttpMethodsClientInterface;
 use PHPUnit\Framework\TestCase;
 
-class TestOrders extends TestCase {
+class OrdersTest extends TestCase {
   private $mock;
   private $stub;
 


### PR DESCRIPTION
💁 I had named these test classes differently from the files themselves, which could be confusing. These changes fix that.