### PR TITLE
API: Order Change Offers

### DIFF
--- a/src/Duffel/Api/OrderChangeOffers.php
+++ b/src/Duffel/Api/OrderChangeOffers.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duffel\Api;
+
+class OrderChangeOffers extends AbstractApi {
+  public function all(string $orderChangeRequestId = '') {
+    if ('' === $orderChangeRequestId) {
+      return $this->get('/air/order_change_offers');
+    }
+
+    return $this->get('/air/order_change_offers?order_change_request_id='.self::encodePath($orderChangeRequestId));
+  }
+
+  public function show(string $id) {
+    return $this->get('/air/order_change_offers/'.self::encodePath($id));
+  }
+}

--- a/src/Duffel/Client.php
+++ b/src/Duffel/Client.php
@@ -10,6 +10,7 @@ use Duffel\Api\Airports;
 use Duffel\Api\OfferRequests;
 use Duffel\Api\Offers;
 use Duffel\Api\OrderCancellations;
+use Duffel\Api\OrderChangeOffers;
 use Duffel\Api\OrderChangeRequests;
 use Duffel\Api\Orders;
 use Duffel\Api\SeatMaps;
@@ -69,6 +70,10 @@ class Client {
 
   public function orderCancellations(): OrderCancellations {
     return new OrderCancellations($this);
+  }
+
+  public function orderChangeOffers(): OrderChangeOffers {
+    return new OrderChangeOffers($this);
   }
 
   public function orderChangeRequests(): OrderChangeRequests {

--- a/tests/Duffel/Api/OrderChangeOffersTest.php
+++ b/tests/Duffel/Api/OrderChangeOffersTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duffel\Tests\Api;
+
+use Duffel\Api\OrderChangeOffers;
+use Duffel\Client;
+use Http\Client\Common\HttpMethodsClientInterface;
+use PHPUnit\Framework\TestCase;
+
+class OrderChangeOffersTest extends TestCase {
+  private $mock;
+  private $stub;
+
+  public function setUp(): void {
+    $this->mock = $this->createMock(HttpMethodsClientInterface::class);
+    $this->stub = $this->createStub(Client::class);
+    $this->stub->method('getHttpClient')
+               ->willReturn($this->mock);
+  }
+
+  public function testAllCallsGetWithExpectedUri(): void {
+    $this->mock->expects($this->once())
+               ->method('get')
+               ->with(
+                 $this->equalTo('/air/order_change_offers'),
+                 $this->equalTo([]),
+               );
+
+    $actual = new OrderChangeOffers($this->stub);
+    $actual->all();
+  }
+
+  public function testAllWithOrderChangeRequestIdCallsGetWithExpectedUri(): void {
+    $this->mock->expects($this->once())
+               ->method('get')
+               ->with(
+                 $this->equalTo('/air/order_change_offers?order_change_request_id=ocr_0000A3bQP9RLVfNUcdpLpw'),
+                 $this->equalTo([]),
+               );
+
+    $actual = new OrderChangeOffers($this->stub);
+    $actual->all('ocr_0000A3bQP9RLVfNUcdpLpw');
+  }
+
+  public function testShowWithIdCallsGetWithExpectedUri(): void {
+    $this->mock->expects($this->once())
+               ->method('get')
+               ->with(
+                 $this->equalTo('/air/order_change_offers/some-id'),
+                 $this->equalTo([]),
+               );
+
+    $actual = new OrderChangeOffers($this->stub);
+    $actual->show('some-id');
+  }
+}
+

--- a/tests/Duffel/ClientTest.php
+++ b/tests/Duffel/ClientTest.php
@@ -10,6 +10,7 @@ use Duffel\Api\Airports;
 use Duffel\Api\OfferRequests;
 use Duffel\Api\Offers;
 use Duffel\Api\OrderCancellations;
+use Duffel\Api\OrderChangeOffers;
 use Duffel\Api\OrderChangeRequests;
 use Duffel\Api\Orders;
 use Duffel\Api\SeatMaps;
@@ -63,6 +64,10 @@ class ClientTest extends TestCase {
 
   public function testOrderCancellationsUsesApiClass(): void {
     $this->assertInstanceOf(OrderCancellations::class, $this->subject->orderCancellations());
+  }
+
+  public function testOrderChangeOffersUsesApiClass(): void {
+    $this->assertInstanceOf(OrderChangeOffers::class, $this->subject->orderChangeOffers());
   }
 
   public function testOrderChangeRequestsUsesApiClass(): void {


### PR DESCRIPTION
💁 These changes add functionality for querying Duffel's [Order Change Offers API](http://duffel.com/docs/api/order-change-offers).