### PR TITLE
API: Payment Intents

### DIFF
--- a/src/Duffel/Api/PaymentIntents.php
+++ b/src/Duffel/Api/PaymentIntents.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duffel\Api;
+
+class PaymentIntents extends AbstractApi {
+  public function create(array $payment) {
+    $params = [
+      'amount' => $payment['amount'],
+      'currency' => $payment['currency'],
+    ];
+
+    return $this->post('/payments/payment_intents', \array_filter($params, function ($value) {
+      return null !== $value && (!\is_string($value) || '' !== $value);
+    }));
+  }
+
+  public function confirm(string $id) {
+    return $this->post('/payments/payment_intents/'.self::encodePath($id).'/actions/confirm');
+  }
+
+  public function show(string $id) {
+    return $this->get('/payments/payment_intents/'.self::encodePath($id));
+  }
+}

--- a/src/Duffel/Client.php
+++ b/src/Duffel/Client.php
@@ -14,6 +14,7 @@ use Duffel\Api\OrderChangeOffers;
 use Duffel\Api\OrderChangeRequests;
 use Duffel\Api\OrderChanges;
 use Duffel\Api\Orders;
+use Duffel\Api\PaymentIntents;
 use Duffel\Api\Payments;
 use Duffel\Api\SeatMaps;
 use Duffel\Exception\InvalidAccessTokenException;
@@ -88,6 +89,10 @@ class Client {
 
   public function orders(): Orders {
     return new Orders($this);
+  }
+
+  public function paymentIntents(): PaymentIntents {
+    return new PaymentIntents($this);
   }
 
   public function payments(): Payments {

--- a/src/Duffel/Client.php
+++ b/src/Duffel/Client.php
@@ -90,7 +90,7 @@ class Client {
     return new Orders($this);
   }
 
-  public function Payments(): Payments {
+  public function payments(): Payments {
     return new Payments($this);
   }
 

--- a/tests/Duffel/Api/PaymentIntentsTest.php
+++ b/tests/Duffel/Api/PaymentIntentsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duffel\Tests\Api;
+
+use Duffel\Api\PaymentIntents;
+use Duffel\Client;
+use Http\Client\Common\HttpMethodsClientInterface;
+use PHPUnit\Framework\TestCase;
+
+class PaymentIntentsTest extends TestCase {
+  private $mock;
+  private $stub;
+
+  public function setUp(): void {
+    $this->mock = $this->createMock(HttpMethodsClientInterface::class);
+    $this->stub = $this->createStub(Client::class);
+    $this->stub->method('getHttpClient')
+               ->willReturn($this->mock);
+  }
+  public function testCreateWithIdCallsGetWithExpectedUri(): void {
+    $this->mock->expects($this->once())
+               ->method('post')
+               ->with(
+                 $this->equalTo('/payments/payment_intents'),
+                 $this->equalTo(['Content-Type' => 'application/json']),
+                 $this->equalTo('{"data":{"amount":"30.20","currency":"GBP"}}'),
+               );
+
+    $actual = new PaymentIntents($this->stub);
+    $actual->create([
+      'amount' => '30.20',
+      'currency' => 'GBP',
+    ]);
+  }
+
+  public function testConfirmWithIdAndPaymentCallsGetWithExpectedUri(): void {
+    $this->mock->expects($this->once())
+               ->method('post')
+               ->with(
+                 $this->equalTo('/payments/payment_intents/some-id/actions/confirm'),
+                 $this->equalTo([]),
+                 $this->equalTo(null),
+               );
+
+    $actual = new PaymentIntents($this->stub);
+    $actual->confirm('some-id', [
+      'type' => 'balance',
+      'currency' => 'GBP',
+      'amount' => '30.20',
+    ]);
+  }
+
+  public function testShowWithIdCallsGetWithExpectedUri(): void {
+    $this->mock->expects($this->once())
+               ->method('get')
+               ->with(
+                 $this->equalTo('/payments/payment_intents/some-id'),
+                 $this->equalTo([]),
+               );
+
+    $actual = new PaymentIntents($this->stub);
+    $actual->show('some-id');
+  }
+
+}

--- a/tests/Duffel/ClientTest.php
+++ b/tests/Duffel/ClientTest.php
@@ -14,6 +14,7 @@ use Duffel\Api\OrderChangeOffers;
 use Duffel\Api\OrderChangeRequests;
 use Duffel\Api\OrderChanges;
 use Duffel\Api\Orders;
+use Duffel\Api\PaymentIntents;
 use Duffel\Api\Payments;
 use Duffel\Api\SeatMaps;
 use Duffel\Client;
@@ -82,6 +83,10 @@ class ClientTest extends TestCase {
 
   public function testOrdersUsesApiClass(): void {
     $this->assertInstanceOf(Orders::class, $this->subject->orders());
+  }
+
+  public function testPaymentIntentsUsesApiClass(): void {
+    $this->assertInstanceOf(PaymentIntents::class, $this->subject->paymentIntents());
   }
 
   public function testPaymentsUsesApiClass(): void {


### PR DESCRIPTION
💁 These changes add functionality for querying Duffel's [Payment Intents API](http://duffel.com/docs/api/payment-intents).