### PR TITLE
API: Refunds

### DIFF
--- a/src/Duffel/Api/Refunds.php
+++ b/src/Duffel/Api/Refunds.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duffel\Api;
+
+class Refunds extends AbstractApi {
+  public function create(array $refund) {
+    $params = [
+      'amount' => $refund['amount'],
+      'currency' => $refund['currency'],
+      'payment_intent_id' => $refund['payment_intent_id'],
+    ];
+
+    return $this->post('/payments/refunds', \array_filter($params, function ($value) {
+      return null !== $value && (!\is_string($value) || '' !== $value);
+    }));
+  }
+
+  public function show(string $id) {
+    return $this->get('/payments/refunds/'.self::encodePath($id));
+  }
+}

--- a/src/Duffel/Client.php
+++ b/src/Duffel/Client.php
@@ -16,6 +16,7 @@ use Duffel\Api\OrderChanges;
 use Duffel\Api\Orders;
 use Duffel\Api\PaymentIntents;
 use Duffel\Api\Payments;
+use Duffel\Api\Refunds;
 use Duffel\Api\SeatMaps;
 use Duffel\Exception\InvalidAccessTokenException;
 use Duffel\HttpClient\Builder;
@@ -97,6 +98,10 @@ class Client {
 
   public function payments(): Payments {
     return new Payments($this);
+  }
+
+  public function refunds(): Refunds {
+    return new Refunds($this);
   }
 
   public function seatMaps(): SeatMaps {

--- a/tests/Duffel/Api/RefundsTest.php
+++ b/tests/Duffel/Api/RefundsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duffel\Tests\Api;
+
+use Duffel\Api\Refunds;
+use Duffel\Client;
+use Http\Client\Common\HttpMethodsClientInterface;
+use PHPUnit\Framework\TestCase;
+
+class RefundsTest extends TestCase {
+  private $mock;
+  private $stub;
+
+  public function setUp(): void {
+    $this->mock = $this->createMock(HttpMethodsClientInterface::class);
+    $this->stub = $this->createStub(Client::class);
+    $this->stub->method('getHttpClient')
+               ->willReturn($this->mock);
+  }
+  public function testCreateWithIdCallsGetWithExpectedUri(): void {
+    $this->mock->expects($this->once())
+               ->method('post')
+               ->with(
+                 $this->equalTo('/payments/refunds'),
+                 $this->equalTo(['Content-Type' => 'application/json']),
+                 $this->equalTo('{"data":{"amount":"30.20","currency":"GBP","payment_intent_id":"pit_00009hthhsUZ8W4LxQgkjo"}}'),
+               );
+
+    $actual = new Refunds($this->stub);
+    $actual->create([
+      'amount' => '30.20',
+      'currency' => 'GBP',
+      'payment_intent_id' => 'pit_00009hthhsUZ8W4LxQgkjo',
+    ]);
+  }
+
+  public function testShowWithIdCallsGetWithExpectedUri(): void {
+    $this->mock->expects($this->once())
+               ->method('get')
+               ->with(
+                 $this->equalTo('/payments/refunds/some-id'),
+                 $this->equalTo([]),
+               );
+
+    $actual = new Refunds($this->stub);
+    $actual->show('some-id');
+  }
+
+}

--- a/tests/Duffel/ClientTest.php
+++ b/tests/Duffel/ClientTest.php
@@ -16,6 +16,7 @@ use Duffel\Api\OrderChanges;
 use Duffel\Api\Orders;
 use Duffel\Api\PaymentIntents;
 use Duffel\Api\Payments;
+use Duffel\Api\Refunds;
 use Duffel\Api\SeatMaps;
 use Duffel\Client;
 use Duffel\Exception\InvalidAccessTokenException;
@@ -95,6 +96,10 @@ class ClientTest extends TestCase {
 
   public function testSeatMapsUsesApiClass(): void {
     $this->assertInstanceOf(SeatMaps::class, $this->subject->seatMaps());
+  }
+
+  public function testRefundsUsesApiClass(): void {
+    $this->assertInstanceOf(Refunds::class, $this->subject->refunds());
   }
 
   public function testSetAccessTokenChangesValue(): void {


### PR DESCRIPTION
💁 These changes add functionality for querying Duffel's [Refunds API](http://duffel.com/docs/api/refunds).