### PR TITLE
WebhookEvent: validate signature

### DIFF
--- a/src/Duffel/Exception/InvalidRequestSignatureException.php
+++ b/src/Duffel/Exception/InvalidRequestSignatureException.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duffel\Exception;
+
+class InvalidRequestSignatureException extends \Exception {
+}

--- a/src/Duffel/WebhookEvent.php
+++ b/src/Duffel/WebhookEvent.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duffel;
+
+use Duffel\Exception\InvalidRequestSignatureException;
+
+final class WebhookEvent {
+  private const SIGNATURE_REGEXP = '/\At=(.+),v1=(.+)\z/';
+
+  /**
+   * @param string $requestBody
+   * @param string $requestSignature
+   * @param string $webhookSecret
+   *
+   * @return bool
+   */
+  public static function isGenuine(string $requestBody, string $requestSignature, string $webhookSecret): bool {
+    try {
+      $parsedSignature = self::parseSignature($requestSignature);
+    } catch(InvalidRequestSignatureException $e) {
+      /*
+      If the signature doesn't even look like a valid one, then the webhook
+      event can't be genuine
+       */
+      return false;
+    }
+
+    $calculatedHmac = self::calculateHmac(
+      $webhookSecret,
+      $requestBody,
+      $parsedSignature['timestamp'],
+    );
+
+    return self::secureCompare($calculatedHmac, $parsedSignature['v1']);
+  }
+
+  /**
+   * @param string $secret
+   * @param string $payload
+   * @param string $timestamp
+   *
+   * @return string
+   */
+  private static function calculateHmac(string $secret, string $payload, string $timestamp): string {
+    $signedPayload = $timestamp.'.'.$payload;
+    $hmacHash = hash_hmac('sha256', $signedPayload, $secret, true);
+    $hmacHashHex = bin2hex($hmacHash);
+
+    return strtolower( trim($hmacHashHex) );
+  }
+
+  /**
+   * @param string $signature
+   *
+   * @return string[]
+   *
+   * @raise InvalidRequestSignatureError
+   */
+  private static function parseSignature(string $signature): array {
+    if (false !== preg_match(self::SIGNATURE_REGEXP, $signature, $matches)) {
+      return [
+        'v1' => $matches[2],
+        'timestamp' => $matches[1],
+      ];
+    } else {
+      throw new InvalidRequestSignatureException();
+    }
+  }
+
+  /**
+   * @param string $a
+   * @param string $b
+   *
+   * @return bool
+   */
+  private static function secureCompare(string $a, string $b): bool {
+    if (mb_strlen($a) !== mb_strlen($b)) {
+      return false;
+    }
+
+    $l = unpack("C*", $a);
+
+    $r = 0;
+    $i = 0;
+
+    foreach(str_split($b) as $v) {
+      $o = mb_ord($v);
+
+      if (\is_int($o)) {
+        $r |= $o ^ $l[$i += 1];
+      }
+    }
+
+    return 0 === $r;
+  }
+}

--- a/tests/Duffel/WebhookEventTest.php
+++ b/tests/Duffel/WebhookEventTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duffel\Tests;
+
+use Duffel\WebhookEvent;
+use PHPUnit\Framework\TestCase;
+
+class WebhookEventTest extends TestCase {
+  private $requestBody;
+  private $requestSignature;
+  private $webhookSecret;
+
+  public function setUp(): void {
+    $this->requestBody = '{"created_at":"2022-01-08T18:44:56.129339Z","data":{"changes":{},"object":{}},' .
+        '"id":"eve_0000AFEsrBKZAcKgGtZCnQ","live_mode":false,"object":"order","type":"' . 
+        'order.updated"}';
+    $this->requestSignature = 't=1641667496,v1=691f25ffb1f206c0fda5bb7b1a9d60fafe42c5f42819d44a06a7cfe09486f102';
+    $this->webhookSecret = 'a_secret';
+  }
+
+  public function testIsGenuineWhenInputIsValid(): void {
+    $this->assertTrue(
+      WebhookEvent::isGenuine($this->requestBody,
+                              $this->requestSignature,
+                              $this->webhookSecret)
+    );
+  }
+
+  public function testIsGenuineWhenRequestSignatureIsInvalid(): void {
+    $requestSignature = 'nah';
+
+    $this->assertFalse(
+      WebhookEvent::isGenuine($this->requestBody,
+                              $requestSignature,
+                              $this->webhookSecret)
+    );
+  }
+
+  public function testIsGenuineWhenRequestBodyDoesNotMatchSignature(): void {
+    $requestBody = 'foo';
+
+    $this->assertFalse(
+      WebhookEvent::isGenuine($requestBody,
+                              $this->requestSignature,
+                              $this->webhookSecret)
+    );
+  }
+}


### PR DESCRIPTION
💁 `Duffel\WebhookEvent` enables a consumer to determine whether a webhook event received from
the Duffel API is genuine or not and is heavily inspired by @timrogers' work in https://duffel.com/docs/guides/receiving-webhooks