### PR TITLE
Docs: update simple example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,15 @@ $ composer require "duffel/api:dev-main" "guzzlehttp/guzzle:^7.4" "http-interop/
 
 ## Usage
 
-A simple example is as follows.
+A simple example of using this library (after successfully installing it) follows.
 
 ```php
-$client = new Duffel/Client();
+use Duffel\Client;
+
+$client = new Duffel\Client();
 $client->setAccessToken(getenv('DUFFEL_ACCESS_TOKEN'));
+
+$client->airports->list();
 ```
 
 See the [`examples/`](./examples) directory for additional working examples.


### PR DESCRIPTION
💁 The previous version of this simple example of using `Duffel\Client` had some errors in the setup and invocation. These changes fix them.