### PR TITLE
Switch version to v1

### DIFF
--- a/src/Duffel/Client.php
+++ b/src/Duffel/Client.php
@@ -35,7 +35,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 
 class Client {
   private const DEFAULT_API_URL = 'https://api.duffel.com/';
-  private const DEFAULT_API_VERSION = 'beta';
+  private const DEFAULT_API_VERSION = 'v1';
   private const VERSION = '0.0.0-alpha';
 
   /**

--- a/tests/Duffel/ClientTest.php
+++ b/tests/Duffel/ClientTest.php
@@ -40,7 +40,7 @@ class ClientTest extends TestCase {
   }
 
   public function testNewSetsDefaultApiVersion(): void {
-    $this->assertSame('beta', $this->subject->getApiVersion());
+    $this->assertSame('v1', $this->subject->getApiVersion());
   }
 
   public function testNewSetsDefaultAccessToken(): void {
@@ -115,13 +115,13 @@ class ClientTest extends TestCase {
 
   public function testSetAccessTokenWithEmptyStringThrowsException(): void {
     $this->expectException(InvalidAccessTokenException::class);
-      
+
     $this->subject->setAccessToken('   ');
   }
 
   public function testSetAccessTokenWithNullThrowsTypeError(): void {
     $this->expectException(\TypeError::class);
-      
+
     $this->subject->setAccessToken(null);
   }
 


### PR DESCRIPTION
We've done a soft release of v1 and will begin using it as there's no material differences to the beta version.