### PR TITLE
Better Dependabot support in composer manifest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,9 @@
     "ergebnis/phpstan-rules": "^1.0",
     "vimeo/psalm": "^4.23"
   },
+  "support": {
+    "source": "https://github.com/sgerrand/duffel-api-php.git"
+  },
   "autoload": {
     "psr-4": { "Duffel\\": "src/Duffel/" }
   },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "library",
   "description": "Duffel API library for PHP",
   "keywords": ["duffel", "flights", "flights-api", "travel"],
-  "homepage": "https://duffel.com",
+  "homepage": "https://github.com/duffel/duffel-api-php",
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
💁 These changes are inspired by @timrogers efforts in https://github.com/duffelhq/duffel-api-javascript/pull/934 to help Dependabot understand the relationships between the project and its dependencies. I don't know whether this library is still maintained but if it is then this change will help.

Supports:
- [relevant part of the `composer.json` schema](https://getcomposer.org/doc/04-schema.md#support)
- [Dependabot implementation for composer](https://github.com/dependabot/dependabot-core/blob/e8d8a1268ea61304e939ba9ab963e249cac5b241/composer/lib/dependabot/composer/metadata_finder.rb#L19-L26)